### PR TITLE
Pin rubocop version at exactly 0.75, to accommodate Hound CI

### DIFF
--- a/raiseme-common.gemspec
+++ b/raiseme-common.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_dependency 'rubocop', '~> 0.72'
+  spec.add_dependency 'rubocop', '0.75'
   spec.add_dependency 'rubocop-rspec', '~> 1.28'
 end


### PR DESCRIPTION
0.75 is the latest version of rubocop supported by Hound (http://help.houndci.com/en/articles/2461415-supported-linters), but currently the gemspec is allowing installation of the latest version. Rubocop has made a number of breaking changes for configuration option names (https://github.com/rubocop-hq/rubocop/issues/7077), in preparation for their 1.0 release, which is breaking linting locally.