### PR TITLE
do not require class-level documentation for test classes

### DIFF
--- a/.rubocop-hound.yml
+++ b/.rubocop-hound.yml
@@ -343,6 +343,7 @@ Style/Documentation:
   Enabled: true
   Exclude:
     - '**/spec/**/*.rb'
+    - '**/test/**/*.rb'
 Style/DoubleNegation:
   Description: Checks for uses of double negation (!!).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-bang-bang


### PR DESCRIPTION
Pluto puts tests into the `test` directory (possibly other projects may choose to do this as well), so Hound currently complains about the lack of test class documentation.