### PR TITLE
Add rubocop-performance

### DIFF
--- a/.rubocop-hound.yml
+++ b/.rubocop-hound.yml
@@ -1,3 +1,4 @@
+require: rubocop-performance
 AllCops:
   Exclude:
     - "linuxgems/nazrin-ebb7848b15e0/**/*"

--- a/.rubocop-hound.yml
+++ b/.rubocop-hound.yml
@@ -401,8 +401,6 @@ Lint/LiteralAsCondition:
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.
   Enabled: false
-Rails/Date:
-  EnforcedStyle: strict
 Style/RedundantBegin:
   Enabled: false
 Performance/TimesMap:

--- a/raiseme-common.gemspec
+++ b/raiseme-common.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_dependency 'rubocop', '0.75'
   spec.add_dependency 'rubocop-rspec', '~> 1.28'
+  spec.add_dependency 'rubocop-performance'
 end


### PR DESCRIPTION
This dependency is needed to elude warnings