### PR TITLE
turn off Style/BracesAroundHashParameters

### DIFF
--- a/.rubocop-hound.yml
+++ b/.rubocop-hound.yml
@@ -426,4 +426,4 @@ Style/WordArray:
 Style/FormatStringToken:
   EnforcedStyle: template
 Style/BracesAroundHashParameters:
-  EnforcedStyle: context_dependent
+  Enabled: false


### PR DESCRIPTION
This cop has actually [been removed](https://github.com/rubocop/rubocop/pull/7643) by rubocop as of 0.80.0 (we run 0.75.0). rubocop has renamed a lot of their rules, so we'd have to sort through some breaking changes in order to upgrade. Hound supports up to Rubocop version 1.5.2: http://help.houndci.com/en/articles/2461415-supported-linters. For now, this PR just disables the rule, so we can stop getting yelled at by Hound for doing the right thing.